### PR TITLE
Automatic full loop option

### DIFF
--- a/SingleEncoder/Program.cs
+++ b/SingleEncoder/Program.cs
@@ -163,7 +163,7 @@ namespace SingleEncoder
                 Console.WriteLine("Usage:");
                 Console.WriteLine("SingleEncoder <InputSCD/Dir> <InputWAV/Dir> <Quality> <FullLoop>");
                 Console.WriteLine("Quality is a range from 0 to 10. Default: 10");
-                Console.WriteLine("FullLoop automatically uses the WAV's entire length as the loop. Enable using -FullLoop or -fl);
+                Console.WriteLine("FullLoop automatically uses the WAV's entire length as the loop. Enable using -FullLoop or -fl");
             }
 
             static void WavtoOGG(string inputWAV, int LoopStart_Sample, int Total_Samples, int Quality)

--- a/SingleEncoder/Program.cs
+++ b/SingleEncoder/Program.cs
@@ -37,16 +37,13 @@ namespace SingleEncoder
                     if (args.Length == 4)
                     {
                         Quality = Convert.ToInt32(args[2]);
-                        FullLoop = Convert.ToBoolean(args[3]);
+                        if (args[3].ToLower() == "-fl" || args[3].ToLower() == "-fullloop")
+                            FullLoop = true;
                     }
                     else if (args.Length == 3)
                     {
-                        string argstring = args[2].ToLower();
-
-                        if (argstring == "-fullloop" || argstring == "-fl")
-                        {
-                            FullLoop = Convert.ToBoolean(argstring);
-                        }
+                        if (args[2].ToLower() == "-fl" || args[2].ToLower() == "-fullloop")
+                            FullLoop = true;
                         else
                             Quality = Convert.ToInt32(args[2]);
                     }

--- a/SingleEncoder/Program.cs
+++ b/SingleEncoder/Program.cs
@@ -30,10 +30,28 @@ namespace SingleEncoder
             {
                 string inputSCD = args[0];
                 int Quality = 10;
+                bool FullLoop = false;
+
                 if (args.Length > 2)
                 {
-                    Quality = Convert.ToInt32(args[2]);
+                    if (args.Length == 4)
+                    {
+                        Quality = Convert.ToInt32(args[2]);
+                        FullLoop = Convert.ToBoolean(args[3]);
+                    }
+                    else if (args.Length == 3)
+                    {
+                        string argstring = args[2].ToLower();
+
+                        if (argstring == "true" || argstring == "false")
+                        {
+                            FullLoop = Convert.ToBoolean(argstring);
+                        }
+                        else
+                            Quality = Convert.ToInt32(args[2]);
+                    }
                 }
+
                 byte[] oldSCD = File.ReadAllBytes(inputSCD);
                 uint tables_offset = Read(oldSCD, 16, 0x0e);
                 uint headers_entries = Read(oldSCD, 16, (int)tables_offset + 0x04);
@@ -48,6 +66,7 @@ namespace SingleEncoder
                 int[] entry_offsets = new int[headers_entries + 1];
                 entry_offsets[0] = file_size;
                 uint codec = getCodec(headers_entries, headers_offset, oldSCD);
+
                 for (int i = 0; i < headers_entries; i++)
                 {
                     entry_begin = Read(oldSCD, 32, (int)headers_offset + i * 0x04);
@@ -69,9 +88,41 @@ namespace SingleEncoder
                         {
                             string wavpath = args[1];
                             byte[] wav = File.ReadAllBytes(wavpath);
-                            //Get Loop Points from Tags
+
+                            //Get Loop Points from Tags 
                             int LoopStart_Sample = searchTag("LoopStart", wav);
                             int Total_Samples = searchTag("LoopEnd", wav);
+                            if (FullLoop) //ignore tags (if they exist or not) and set song to be a full loop instead
+                            {
+                                byte[] fmtPattern = Encoding.ASCII.GetBytes("fmt ");
+                                byte[] datPattern = Encoding.ASCII.GetBytes("data");
+                                int typepos = SearchBytePattern(0, wav, fmtPattern);
+                                int datapos = SearchBytePattern(0, wav, datPattern);
+
+                                if (typepos != -1 && datapos != -1)
+                                {
+                                    short type = BitConverter.ToInt16(wav, typepos + 20);
+                                    int datasize = BitConverter.ToInt32(wav, datapos + 4);
+
+                                    if (datasize < wav.Length)
+                                    {
+                                        LoopStart_Sample = 0; //always 0
+                                        Total_Samples = datasize / type;
+                                    }
+                                    else
+                                    {
+                                        Console.WriteLine("Total samples larger than WAV filesize!");
+                                        Console.WriteLine("Continuing and making SCD with no loop...");
+
+                                    }
+                                }
+                                else
+                                {
+                                    Console.WriteLine("Could not get data for Full Loop! Wrong WAV format?");
+                                    Console.WriteLine("Continuing and making SCD with no loop...");
+                                }
+                            }
+
                             WavtoOGG(wavpath, LoopStart_Sample, Total_Samples, Quality);
                             string oggPath = Path.Combine(Path.GetDirectoryName(AppContext.BaseDirectory), $"{Path.GetFileNameWithoutExtension(wavpath)}.ogg");
                             newEntry = OGGtoSCD(wav, entry, oggPath, LoopStart_Sample, Total_Samples);
@@ -110,7 +161,9 @@ namespace SingleEncoder
             else
             {
                 Console.WriteLine("Usage:");
-                Console.WriteLine("SingleEncoder <InputSCD/Dir> <InputWAV/Dir>");
+                Console.WriteLine("SingleEncoder <InputSCD/Dir> <InputWAV/Dir> <Quality> <FullLoop>");
+                Console.WriteLine("Quality is a range from 0 to 10. Default: 10");
+                Console.WriteLine("FullLoop automatically uses the WAV's entire length as the loop if True. Default: False");
             }
 
             static void WavtoOGG(string inputWAV, int LoopStart_Sample, int Total_Samples, int Quality)

--- a/SingleEncoder/Program.cs
+++ b/SingleEncoder/Program.cs
@@ -43,7 +43,7 @@ namespace SingleEncoder
                     {
                         string argstring = args[2].ToLower();
 
-                        if (argstring == "true" || argstring == "false")
+                        if (argstring == "-fullloop" || "-fl")
                         {
                             FullLoop = Convert.ToBoolean(argstring);
                         }
@@ -111,15 +111,15 @@ namespace SingleEncoder
                                     }
                                     else
                                     {
-                                        Console.WriteLine("Total samples larger than WAV filesize!");
-                                        Console.WriteLine("Continuing and making SCD with no loop...");
+                                        Console.WriteLine("Total samples larger than WAV filesize! Wrong WAV format?");
+                                        Console.WriteLine("Continuing without making automatic full loop...");
 
                                     }
                                 }
                                 else
                                 {
                                     Console.WriteLine("Could not get data for Full Loop! Wrong WAV format?");
-                                    Console.WriteLine("Continuing and making SCD with no loop...");
+                                    Console.WriteLine("Continuing  without making automatic full loop...");
                                 }
                             }
 
@@ -163,7 +163,7 @@ namespace SingleEncoder
                 Console.WriteLine("Usage:");
                 Console.WriteLine("SingleEncoder <InputSCD/Dir> <InputWAV/Dir> <Quality> <FullLoop>");
                 Console.WriteLine("Quality is a range from 0 to 10. Default: 10");
-                Console.WriteLine("FullLoop automatically uses the WAV's entire length as the loop if True. Default: False");
+                Console.WriteLine("FullLoop automatically uses the WAV's entire length as the loop. Enable using -FullLoop or -fl);
             }
 
             static void WavtoOGG(string inputWAV, int LoopStart_Sample, int Total_Samples, int Quality)

--- a/SingleEncoder/Program.cs
+++ b/SingleEncoder/Program.cs
@@ -43,7 +43,7 @@ namespace SingleEncoder
                     {
                         string argstring = args[2].ToLower();
 
-                        if (argstring == "-fullloop" || "-fl")
+                        if (argstring == "-fullloop" || argstring == "-fl")
                         {
                             FullLoop = Convert.ToBoolean(argstring);
                         }


### PR DESCRIPTION
A pretty simple quality of life option to automatically have SingleEncoder determine and set the input WAV to use a full loop without the need to create tags.
All that is needed is to use `-FullLoop` or `-fl` at the end of your argument and the program will set loop start to 0 and find the total samples for the WAV to use for the loop end. If the WAV has existing Loop_Start/Loop_End tags then those will just be ignored with this option on in favor of a full loop.